### PR TITLE
Add skywork_chat template

### DIFF
--- a/src/llama-chat.h
+++ b/src/llama-chat.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 enum llm_chat_template {
     LLM_CHAT_TEMPLATE_CHATML,
@@ -47,6 +47,7 @@ enum llm_chat_template {
     LLM_CHAT_TEMPLATE_DOTS1,
     LLM_CHAT_TEMPLATE_HUNYUAN_MOE,
     LLM_CHAT_TEMPLATE_KIMI_K2,
+    LLM_CHAT_TEMPLATE_SKYWORK_CHAT,
     LLM_CHAT_TEMPLATE_UNKNOWN,
 };
 
@@ -56,7 +57,5 @@ llm_chat_template llm_chat_template_from_str(const std::string & name);
 
 llm_chat_template llm_chat_detect_template(const std::string & tmpl);
 
-int32_t llm_chat_apply_template(
-    llm_chat_template tmpl,
-    const std::vector<const llama_chat_message *> & chat,
-    std::string & dest, bool add_ass);
+int32_t llm_chat_apply_template(llm_chat_template tmpl, const std::vector<const llama_chat_message *> & chat,
+                                std::string & dest, bool add_ass);


### PR DESCRIPTION
## Summary
- add `skywork_chat` enum in `llama-chat.h`
- support `skywork_chat` in template map
- detect `skywork_chat` heuristically
- implement formatting logic for the template

## Testing
- `cmake -S . -B build -DLLAMA_BUILD_TESTS=ON` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687b572476e083288c1728c915ab66f2