### PR TITLE
Add CodeGen model support

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3365,6 +3365,33 @@ class GPT2Model(TextModel):
         return tensors
 
 
+@ModelBase.register("CodeGenForCausalLM")
+class CodeGenModel(TextModel):
+    model_arch = gguf.MODEL_ARCH.CODEGEN
+
+    def set_gguf_parameters(self):
+        self.gguf_writer.add_block_count(self.hparams["n_layer"])
+        self.gguf_writer.add_context_length(self.hparams.get("n_positions", self.hparams.get("n_ctx", 0)))
+        self.gguf_writer.add_embedding_length(self.hparams["n_embd"])
+        inner_dim = self.hparams.get("n_inner", 4 * self.hparams["n_embd"])
+        self.gguf_writer.add_feed_forward_length(inner_dim)
+        self.gguf_writer.add_head_count(self.hparams["n_head"])
+        self.gguf_writer.add_layer_norm_eps(self.hparams.get("layer_norm_epsilon", self.hparams.get("layer_norm_eps")))
+        self.gguf_writer.add_rope_dimension_count(self.hparams.get("rotary_dim", 0))
+        self.gguf_writer.add_file_type(self.ftype)
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        del bid  # unused
+
+        if name.endswith((".attn.bias", ".attn.masked_bias")):
+            return []
+
+        if name.endswith((".qkv_proj.weight", ".out_proj.weight", ".qkv_proj.bias", ".out_proj.bias")):
+            data_torch = data_torch.transpose(1, 0)
+
+        return [(self.map_tensor_name(name), data_torch)]
+
+
 @ModelBase.register("PhiForCausalLM")
 class Phi2Model(TextModel):
     model_arch = gguf.MODEL_ARCH.PHI2

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -297,6 +297,7 @@ class MODEL_ARCH(IntEnum):
     GPT2             = auto()
     GPTJ             = auto()
     GPTNEOX          = auto()
+    CODEGEN          = auto()
     MPT              = auto()
     STARCODER        = auto()
     REFACT           = auto()
@@ -615,6 +616,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.GPT2:             "gpt2",
     MODEL_ARCH.GPTJ:             "gptj",
     MODEL_ARCH.GPTNEOX:          "gptneox",
+    MODEL_ARCH.CODEGEN:          "codegen",
     MODEL_ARCH.MPT:              "mpt",
     MODEL_ARCH.STARCODER:        "starcoder",
     MODEL_ARCH.REFACT:           "refact",
@@ -1070,6 +1072,18 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
     ],
     MODEL_ARCH.GPTNEOX: [
         MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT_NORM,
+        MODEL_TENSOR.OUTPUT,
+        MODEL_TENSOR.ATTN_NORM,
+        MODEL_TENSOR.ATTN_QKV,
+        MODEL_TENSOR.ATTN_OUT,
+        MODEL_TENSOR.FFN_NORM,
+        MODEL_TENSOR.FFN_DOWN,
+        MODEL_TENSOR.FFN_UP,
+    ],
+    MODEL_ARCH.CODEGEN: [
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.POS_EMBD,
         MODEL_TENSOR.OUTPUT_NORM,
         MODEL_TENSOR.OUTPUT,
         MODEL_TENSOR.ATTN_NORM,


### PR DESCRIPTION
## Summary
- add a CODEGEN architecture to GGUF constants
- register CodeGenForCausalLM for conversion

## Testing
- `pre-commit run --files gguf-py/gguf/constants.py convert_hf_to_gguf.py` *(fails: dependency conflict)*
- `pytest -q` *(fails: ModuleNotFoundError: wget)*

------
https://chatgpt.com/codex/tasks/task_e_687e00293cc08328b4c36b0d75885500