### PR TITLE
Fix CodeGen tensor mapping

### DIFF
--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -167,6 +167,7 @@ class TensorNameMap:
             "model.layers.layers.{bid}.mixer.qkv_proj",                            # plamo2
             "encoder.layers.{bid}.self_attention.query_key_value",                 # chatglm
             "transformer.layers.{bid}.attn.qkv_proj",                              # openelm
+            "transformer.h.{bid}.attn.qkv_proj",   # codegen
             "transformer_encoder.{bid}.qkv",                                       # neobert
         ),
 


### PR DESCRIPTION
## Summary
- add missing CodeGen tensor name for qkv projection

## Testing
- `pytest gguf-py/tests/test_metadata.py gguf-py/tests/test_quants.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e0ba9f6ac8328afa817da35f20e52