### PR TITLE
Fix duplicate CodeGen switch cases

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -980,7 +980,6 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                }
             } break;
         case LLM_ARCH_GPT2:
-        case LLM_ARCH_CODEGEN:
             {
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_EPS, hparams.f_norm_eps);
                 switch (hparams.n_layer) {
@@ -3081,7 +3080,6 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                     }
                 } break;
             case LLM_ARCH_GPT2:
-            case LLM_ARCH_CODEGEN:
                 {
                     tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
                     pos_embd = create_tensor(tn(LLM_TENSOR_POS_EMBD,   "weight"), {n_embd, n_ctx_train}, 0);
@@ -17214,7 +17212,6 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
                 llm = std::make_unique<llm_build_plamo2>(*this, params);
             } break;
         case LLM_ARCH_GPT2:
-        case LLM_ARCH_CODEGEN:
             {
                 llm = std::make_unique<llm_build_gpt2>(*this, params);
             } break;


### PR DESCRIPTION
## Summary
- remove duplicate `LLM_ARCH_CODEGEN` case labels from GPT-2 switch blocks
- successfully build project with cmake

## Testing
- `cmake -B build`
- `cmake --build build -j4`


------
https://chatgpt.com/codex/tasks/task_e_687e45e3fb6883289db34d7d885be512