### PR TITLE
Fix CodeGen metadata missing parallel residual key

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3381,6 +3381,7 @@ class CodeGenModel(TextModel):
             inner_dim = 4 * self.hparams["n_embd"]
         self.gguf_writer.add_feed_forward_length(inner_dim)
         self.gguf_writer.add_head_count(self.hparams["n_head"])
+        self.gguf_writer.add_parallel_residual(self.hparams.get("use_parallel_residual", True))
         self.gguf_writer.add_layer_norm_eps(self.hparams.get("layer_norm_epsilon", self.hparams.get("layer_norm_eps")))
         self.gguf_writer.add_rope_dimension_count(self.hparams.get("rotary_dim", 0))
         self.gguf_writer.add_file_type(self.ftype)


### PR DESCRIPTION
## Summary
- ensure `convert_hf_to_gguf.py` writes `use_parallel_residual` for CodeGen models

## Testing
- `python3 -m py_compile convert_hf_to_gguf.py`
- *(failed to install python dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687e4c5aaf1083289fc159bb5c40a2a3