### PR TITLE
Add optional qkv bias support for CodeGen

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -3369,6 +3369,10 @@ class GPT2Model(TextModel):
 class CodeGenModel(TextModel):
     model_arch = gguf.MODEL_ARCH.CODEGEN
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._found_qkv_bias = False
+
     def set_gguf_parameters(self):
         self.gguf_writer.add_block_count(self.hparams["n_layer"])
         self.gguf_writer.add_context_length(self.hparams.get("n_positions", self.hparams.get("n_ctx", 0)))
@@ -3384,6 +3388,7 @@ class CodeGenModel(TextModel):
         self.gguf_writer.add_parallel_residual(self.hparams.get("use_parallel_residual", True))
         self.gguf_writer.add_layer_norm_eps(self.hparams.get("layer_norm_epsilon", self.hparams.get("layer_norm_eps")))
         self.gguf_writer.add_rope_dimension_count(self.hparams.get("rotary_dim", 0))
+        self.gguf_writer.add_use_qkv_bias(self.hparams.get("qkv_proj_bias", True))
         self.gguf_writer.add_file_type(self.ftype)
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
@@ -3398,7 +3403,24 @@ class CodeGenModel(TextModel):
             if data_torch.ndim == 2:
                 data_torch = data_torch.transpose(1, 0)
 
+        if name.endswith(".qkv_proj.bias"):
+            self._found_qkv_bias = True
+
         return [(self.map_tensor_name(name), data_torch)]
+
+    def prepare_tensors(self):
+        super().prepare_tensors()
+
+        if not self._found_qkv_bias:
+            if not self.hparams.get("qkv_proj_bias", True):
+                self.gguf_writer.add_use_qkv_bias(False)
+                return
+            self.gguf_writer.add_use_qkv_bias(True)
+            n_embd = self.hparams["n_embd"]
+            for bid in range(self.hparams["n_layer"]):
+                bias = torch.zeros(3 * n_embd, dtype=torch.float32)
+                name = self.format_tensor_name(gguf.MODEL_TENSOR.ATTN_QKV, bid, suffix=".bias")
+                self.gguf_writer.add_tensor(name, bias.numpy())
 
 
 @ModelBase.register("PhiForCausalLM")

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -144,6 +144,7 @@ class Keys:
         REL_BUCKETS_COUNT            = "{arch}.attention.relative_buckets_count"
         SLIDING_WINDOW               = "{arch}.attention.sliding_window"
         SCALE                        = "{arch}.attention.scale"
+        USE_QKV_BIAS                 = "{arch}.attention.use_qkv_bias"
         KEY_LENGTH_MLA               = "{arch}.attention.key_length_mla"
         VALUE_LENGTH_MLA             = "{arch}.attention.value_length_mla"
         SHARED_KV_LAYERS             = "{arch}.attention.shared_kv_layers"
@@ -2778,6 +2779,7 @@ KEY_ATTENTION_HEAD_COUNT        = Keys.Attention.HEAD_COUNT
 KEY_ATTENTION_HEAD_COUNT_KV     = Keys.Attention.HEAD_COUNT_KV
 KEY_ATTENTION_MAX_ALIBI_BIAS    = Keys.Attention.MAX_ALIBI_BIAS
 KEY_ATTENTION_CLAMP_KQV         = Keys.Attention.CLAMP_KQV
+KEY_ATTENTION_USE_QKV_BIAS      = Keys.Attention.USE_QKV_BIAS
 KEY_ATTENTION_LAYERNORM_EPS     = Keys.Attention.LAYERNORM_EPS
 KEY_ATTENTION_LAYERNORM_RMS_EPS = Keys.Attention.LAYERNORM_RMS_EPS
 

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -699,6 +699,9 @@ class GGUFWriter:
         else:
             self.add_array(Keys.Attention.HEAD_COUNT_KV.format(arch=self.arch), count)
 
+    def add_use_qkv_bias(self, use: bool) -> None:
+        self.add_bool(Keys.Attention.USE_QKV_BIAS.format(arch=self.arch), use)
+
     def add_key_length(self, length: int) -> None:
         self.add_uint32(Keys.Attention.KEY_LENGTH.format(arch=self.arch), length)
 

--- a/gguf-py/tests/test_codegen_bias.py
+++ b/gguf-py/tests/test_codegen_bias.py
@@ -1,0 +1,69 @@
+import os
+import json
+import tempfile
+import unittest
+
+import pytest
+pytest.importorskip("torch")
+
+import torch
+import numpy as np
+import gguf
+from pathlib import Path
+
+from convert_hf_to_gguf import CodeGenModel
+
+class TestCodeGenBias(unittest.TestCase):
+    def _create_model(self, dir_model: str, with_bias: bool):
+        cfg = {
+            "architectures": ["CodeGenForCausalLM"],
+            "n_layer": 1,
+            "n_embd": 4,
+            "n_head": 1,
+            "n_positions": 4,
+            "n_ctx": 4,
+            "n_inner": 8,
+            "vocab_size": 8,
+            "qkv_proj_bias": with_bias,
+        }
+        with open(os.path.join(dir_model, "config.json"), "w") as f:
+            json.dump(cfg, f)
+        sd = {
+            "transformer.wte.weight": torch.zeros(8, 4),
+            "transformer.ln_f.weight": torch.ones(4),
+            "transformer.h.0.ln_1.weight": torch.ones(4),
+            "transformer.h.0.attn.qkv_proj.weight": torch.zeros(12,4),
+            "transformer.h.0.attn.out_proj.weight": torch.zeros(4,4),
+            "transformer.h.0.ln_2.weight": torch.ones(4),
+            "transformer.h.0.mlp.c_fc.weight": torch.zeros(8,4),
+            "transformer.h.0.mlp.c_proj.weight": torch.zeros(4,8),
+            "lm_head.weight": torch.zeros(8,4),
+        }
+        if with_bias:
+            sd["transformer.h.0.attn.qkv_proj.bias"] = torch.zeros(12)
+        torch.save(sd, os.path.join(dir_model, "pytorch_model.bin"))
+
+    def _convert(self, with_bias: bool):
+        with tempfile.TemporaryDirectory() as d:
+            self._create_model(d, with_bias)
+            out = Path(d) / "out.gguf"
+            model = CodeGenModel(Path(d), gguf.LlamaFileType.F32, out)
+            model.write()
+            reader = gguf.GGUFReader(out)
+            key = gguf.KEY_ATTENTION_USE_QKV_BIAS.format(arch="codegen")
+            val = reader.get_kv(key)
+            has_tensor = "blk.0.attn_qkv.bias" in reader.tensors
+            return val, has_tensor
+
+    def test_biasless_codegen(self):
+        val, has_tensor = self._convert(False)
+        self.assertFalse(val)
+        self.assertFalse(has_tensor)
+
+    def test_bias_codegen(self):
+        val, has_tensor = self._convert(True)
+        self.assertTrue(val)
+        self.assertTrue(has_tensor)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support optional qkv bias for CodeGen models when converting HF checkpoints
- expose `attention.use_qkv_bias` metadata and writer API
- create zero bias when config expects bias but weights omit it
- add unit test for CodeGen bias handling

## Testing
- `pytest gguf-py/tests/test_codegen_bias.py -k bias` *(fails: no tests run)*
- `flake8 gguf-py/gguf/constants.py gguf-py/gguf/gguf_writer.py convert_hf_to_gguf.py gguf-py/tests/test_codegen_bias.py` *(failed to run due to dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_687e677a4cb0832886d3a41f49a663b0